### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,10 @@
 
 name: Go
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/nyasuto/db/security/code-scanning/1](https://github.com/nyasuto/db/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow:
1. The `actions/checkout` and `actions/setup-go` steps likely only need `contents: read` permissions.
2. The `reviewdog/action-golangci-lint` step interacts with pull requests, so it may require `pull-requests: write` permissions.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build` job. In this case, we will add it at the root level for simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
