### PR TITLE
feat: Stage 1 - Basic Read/Write Log Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ponpoko-KV: A Bitcask-inspired High Performance KVS
+# A Bitcask-inspired High Performance KVS
 
 「シンプルから高度なエンジンへ」の進化を記録する、Go製の自作KVSプロジェクト。
 

--- a/docs/BENCHMARK_STAGE1.md
+++ b/docs/BENCHMARK_STAGE1.md
@@ -1,0 +1,52 @@
+# Stage 1 Benchmark Report
+
+## 実行環境
+- **OS**: macOS (darwin/arm64)
+- **CPU**: Apple M4 Pro
+- **Date**: 2026-01-03
+
+## パフォーマンス・サマリー
+
+### 書き込み性能 (Put)
+| Payload Size | Latency (平均応答時間) | Throughput (推定処理能力) | Memory Allocations |
+|--------------|------------------------|---------------------------|--------------------|
+| **Small** (~8B) | **1.34 µs**            | **約 747,300 ops/sec**    | 189 B/op           |
+| **1 KB**       | **1.99 µs**            | **約 503,000 ops/sec**    | 1,278 B/op         |
+
+### 読み込み性能 (Get)
+| Payload Size | Latency (平均応答時間) | Throughput (推定処理能力) | Memory Allocations |
+|--------------|------------------------|---------------------------|--------------------|
+| **Small** (~8B) | **0.73 µs**            | **約 1,373,000 ops/sec**  | 21 B/op            |
+| **1 KB**       | **0.95 µs**            | **約 1,051,000 ops/sec**  | 2,193 B/op         |
+
+### 評価と考察
+1. **スケーラビリティ**:
+   - データサイズが数バイトから1KBへ約100倍になっても、レイテンシの増加は **1.5倍程度** (Put: 1.34µs -> 1.99µs, Get: 0.73µs -> 0.95µs) に留まっています。
+   - これは、ログ型構造（LSM/Bitcaskモデル）の強みである「シーケンシャル書き込み」と「ダイレクト読み込み」効率の良さを示しています。
+
+2. **ボトルネック**:
+   - 現在のボトルネックはディスクI/Oよりも、システムコールやメモリアロケーションのオーバーヘッドが支配的であると考えられます（1KB程度であればOSのページキャッシュに乗るため）。
+
+---
+
+## 生データ (Raw Output)
+```text
+=== RUN   TestPutGet
+--- PASS: TestPutGet (0.00s)
+=== RUN   TestRecovery
+--- PASS: TestRecovery (0.00s)
+goos: darwin
+goarch: arm64
+pkg: bitcask-go/internal/storage
+cpu: Apple M4 Pro
+BenchmarkPut
+BenchmarkPut-14           897561              1338 ns/op             189 B/op          5 allocs/op
+BenchmarkPut1KB
+BenchmarkPut1KB-14        643522              1988 ns/op            1278 B/op          4 allocs/op
+BenchmarkGet
+BenchmarkGet-14          1690966               728.2 ns/op            21 B/op          2 allocs/op
+BenchmarkGet1KB
+BenchmarkGet1KB-14       1294184               951.3 ns/op          2193 B/op          3 allocs/op
+PASS
+ok      bitcask-go/internal/storage     7.241s
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module bitcask-go
+
+go 1.25.2

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -1,0 +1,185 @@
+package storage
+
+import (
+	"encoding/binary"
+	"errors"
+	"os"
+	"sync"
+	"time"
+)
+
+var ErrKeyNotFound = errors.New("key not found")
+
+// RecordPos はファイル内でのレコードの位置情報を保持します。
+type RecordPos struct {
+	Offset int64
+}
+
+// DB は Bitcask モデルの簡易的な KVS エンジンです。
+type DB struct {
+	mu     sync.RWMutex
+	file   *os.File
+	keyDir map[string]RecordPos
+	offset int64
+}
+
+// NewDB は指定されたパスでデータベースを開きます。
+func NewDB(path string) (*DB, error) {
+	// ファイルを開く（追記モード）
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	stat, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+
+	db := &DB{
+		file:   file,
+		keyDir: make(map[string]RecordPos),
+		offset: stat.Size(),
+	}
+
+	// 既存データがある場合はインデックスを復元
+	if stat.Size() > 0 {
+		if err := db.loadKeyDir(); err != nil {
+			file.Close()
+			return nil, err
+		}
+	}
+
+	return db, nil
+}
+
+// loadKeyDir はファイル全体を走査してインデックスを再構築します。
+func (d *DB) loadKeyDir() error {
+	// ファイルの先頭から読み込むためにSeekする
+	// ただし、DBのメインのoffsetは追記用なので動かしたくないが、
+	// NewDBの中なのでまだPutは走らない。
+	// 安全のため、ReadAtを使うか、一時的にSeekして戻すか。
+	// ここでは構造上、NewDB内でのみ呼ばれる前提で、Read系関数を使う。
+	// しかし効率化のため bufio を使いたいが、標準ライブラリ制約と構造体のシンプルさを優先し、
+	// os.FileのReadで順次読み進める。
+
+	// 現在のファイルポインタを保存（通常は0か末尾のはずだが念のため）
+	// O_APPENDモードのファイルに対してSeekしてもWrite位置は常に末尾になるが、
+	// Read位置はSeekの影響を受ける。
+	if _, err := d.file.Seek(0, 0); err != nil {
+		return err
+	}
+
+	var offset int64
+	fileSize := d.offset // NewDBで設定済み
+
+	for offset < fileSize {
+		// ヘッダー読み込み
+		header := make([]byte, 16)
+		if _, err := d.file.Read(header); err != nil {
+			return err
+		}
+
+		// サイズ取得
+		keySize := int64(binary.BigEndian.Uint32(header[8:12]))
+		valSize := int64(binary.BigEndian.Uint32(header[12:16]))
+		totalSize := 16 + keySize + valSize
+
+		// キーを読み込む
+		key := make([]byte, keySize)
+		if _, err := d.file.Read(key); err != nil {
+			return err
+		}
+
+		// インデックス更新
+		d.keyDir[string(key)] = RecordPos{Offset: offset}
+
+		// 値の部分をスキップ
+		if _, err := d.file.Seek(valSize, 1); err != nil { // 1 = io.SeekCurrent
+			return err
+		}
+
+		offset += totalSize
+	}
+
+	return nil
+}
+
+// Close はデータベースを閉じます。
+func (d *DB) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.file.Close()
+}
+
+// Put はキーと値を保存します。
+func (d *DB) Put(key, value []byte) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	ts := time.Now().UnixNano()
+	keySize := uint32(len(key))
+	valSize := uint32(len(value))
+	totalSize := 8 + 4 + 4 + int64(keySize) + int64(valSize)
+
+	// バッファの作成
+	// [Timestamp(8)][KeySize(4)][ValueSize(4)][Key...][Value...]
+	buf := make([]byte, totalSize)
+	binary.BigEndian.PutUint64(buf[0:8], uint64(ts))
+	binary.BigEndian.PutUint32(buf[8:12], keySize)
+	binary.BigEndian.PutUint32(buf[12:16], valSize)
+	copy(buf[16:16+keySize], key)
+	copy(buf[16+keySize:], value)
+
+	// ファイルへの書き込み
+	if _, err := d.file.Write(buf); err != nil {
+		return err
+	}
+
+	// インデックスの更新
+	d.keyDir[string(key)] = RecordPos{Offset: d.offset}
+	d.offset += totalSize
+
+	return nil
+}
+
+// Get はキーに対応する値を取得します。
+func (d *DB) Get(key []byte) ([]byte, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	pos, ok := d.keyDir[string(key)]
+	if !ok {
+		return nil, ErrKeyNotFound
+	}
+
+	// ヘッダー読み込み (Timestamp + KeySize + ValueSize = 16 bytes)
+	header := make([]byte, 16)
+	if _, err := d.file.ReadAt(header, pos.Offset); err != nil {
+		return nil, err
+	}
+
+	keySize := binary.BigEndian.Uint32(header[8:12])
+	valSize := binary.BigEndian.Uint32(header[12:16])
+
+	// KeyとValueを読み込む
+	// データ位置 = Offset + 16
+	data := make([]byte, keySize+valSize)
+	if _, err := d.file.ReadAt(data, pos.Offset+16); err != nil {
+		return nil, err
+	}
+
+	// キーの一致確認（念のため）
+	readKey := data[:keySize]
+	if string(readKey) != string(key) {
+		return nil, errors.New("data corruption: key mismatch")
+	}
+
+	readValue := data[keySize:]
+	// 呼び出し元が変更しても安全なようにコピーを返す
+	result := make([]byte, len(readValue))
+	copy(result, readValue)
+
+	return result, nil
+}

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -1,0 +1,178 @@
+package storage
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestPutGet(t *testing.T) {
+	dbPath := "test_db.data"
+	defer os.Remove(dbPath)
+
+	db, err := NewDB(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open DB: %v", err)
+	}
+	defer db.Close()
+
+	key := []byte("my-key")
+	value := []byte("my-value")
+
+	if err := db.Put(key, value); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+
+	got, err := db.Get(key)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	if string(got) != string(value) {
+		t.Errorf("Expected %s, got %s", string(value), string(got))
+	}
+}
+
+func TestRecovery(t *testing.T) {
+	dbPath := "test_recovery.data"
+	defer os.Remove(dbPath)
+
+	// 1. 書き込み
+	db, err := NewDB(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open DB: %v", err)
+	}
+
+	key := []byte("persistent-key")
+	value := []byte("persistent-value")
+
+	if err := db.Put(key, value); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+	db.Close() // ここで閉じる
+
+	// 2. 再起動と読み込み
+	db2, err := NewDB(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to re-open DB: %v", err)
+	}
+	defer db2.Close()
+
+	got, err := db2.Get(key)
+	if err != nil {
+		t.Fatalf("Get after recovery failed: %v", err)
+	}
+
+	if string(got) != string(value) {
+		t.Errorf("Expected %s, got %s", string(value), string(got))
+	}
+}
+
+func BenchmarkPut(b *testing.B) {
+	dbPath := "bench_put.data"
+	defer os.Remove(dbPath)
+
+	db, err := NewDB(dbPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := []byte(fmt.Sprintf("key-%d", i))
+		val := []byte(fmt.Sprintf("val-%d", i))
+		if err := db.Put(key, val); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPut1KB(b *testing.B) {
+	dbPath := "bench_put_1kb.data"
+	defer os.Remove(dbPath)
+
+	db, err := NewDB(dbPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	// 1KB のダミーデータを作成
+	val := make([]byte, 1024)
+	for i := range val {
+		val[i] = 'x'
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := []byte(fmt.Sprintf("key-%d", i))
+		// valは使い回す（内容生成時間は計測外）
+		if err := db.Put(key, val); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGet(b *testing.B) {
+	dbPath := "bench_get.data"
+	defer os.Remove(dbPath)
+
+	db, err := NewDB(dbPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	// データを事前に書き込む
+	const itemCount = 1000
+	for i := 0; i < itemCount; i++ {
+		key := []byte(fmt.Sprintf("key-%d", i))
+		val := []byte(fmt.Sprintf("val-%d", i))
+		if err := db.Put(key, val); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := []byte(fmt.Sprintf("key-%d", i%itemCount))
+		if _, err := db.Get(key); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGet1KB(b *testing.B) {
+	dbPath := "bench_get_1kb.data"
+	defer os.Remove(dbPath)
+
+	db, err := NewDB(dbPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	// データを事前に書き込む (10,000件 x 1KB ≒ 10MB)
+	const itemCount = 10000
+	val := make([]byte, 1024)
+	for i := range val {
+		val[i] = 'x'
+	}
+
+	for i := 0; i < itemCount; i++ {
+		key := []byte(fmt.Sprintf("key-%d", i))
+		if err := db.Put(key, val); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// ランダムアクセス風にキーを選択
+		key := []byte(fmt.Sprintf("key-%d", i%itemCount))
+		if _, err := db.Get(key); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## 概要
Bitcask 論文に基づいた Stage 1 (The Log) の実装を行いました。

## 実装内容
- **データフォーマット**: バイナリ形式での追記型書き込み
- **インデックス**: メモリ上の `KeyDir` (Hash Map) によるオフセット管理
- **API**: `Put`, `Get`, `Close` の実装
- **永続化**: 再起動時のインデックス復元 (`Recovery`) 機能

## ベンチマーク結果
`docs/BENCHMARK_STAGE1.md` 参照。
- Put: ~500k ops/sec (1KB payload)
- Get: ~1M ops/sec (1KB payload)