### PR TITLE
feat: Stage 2 - Implement Compaction (Merge)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,16 @@ tidy: ## go.mod の依存関係を整理します
 lint: ## golangci-lint を実行します (brew install golangci-lint などでインストールが必要)
 	$(GOLINT) run
 
+quality: tidy lint test ## コード品質チェック（tidy, lint, test）を一括実行します
+
+setup-hooks: ## git hooks (pre-push) をインストールします
+	@mkdir -p .git/hooks
+	@echo '#!/bin/sh' > .git/hooks/pre-push
+	@echo 'echo "Running pre-push quality checks..."' >> .git/hooks/pre-push
+	@echo 'make quality' >> .git/hooks/pre-push
+	@chmod +x .git/hooks/pre-push
+	@echo "Git pre-push hook installed successfully."
+
 clean: ## テストで生成されたデータファイルやキャッシュを削除します
 	rm -f *.data
 	$(GOCMD) clean

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -112,7 +112,9 @@ func (d *DB) Merge() error {
 	if err := d.file.Close(); err != nil {
 		return err
 	}
-	tempFile.Close() // deferでも呼ばれるが、Rename前に明示的に閉じる必要あり(Windows等考慮)
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
 
 	// 2. リネーム (Atomic Replace)
 	if err := os.Rename(tempPath, d.path); err != nil {


### PR DESCRIPTION
## 概要
Stage 2 の後半パートである、データファイルのコンパクション (Compaction/Merge) 機能を実装しました。

## 実装内容
- **`Merge()` API**:
    - **動作**: 現在のデータファイルをスキャンし、有効な（最新かつ未削除の）レコードのみを一時ファイルに書き出します。
    - **アトミック更新**: 書き出し完了後、`os.Rename` を用いて既存のデータファイルを一気に入れ替えます。
    - **効果**: 上書きされた古い値や Tombstone (削除済みキー) が物理的に削除され、ディスク容量が回収されます。

## テスト
- **`TestMerge`**:
    - 上書き・削除を含む操作を行った後、`Merge()` を実行。
    - ファイルサイズが削減されることを確認。
    - 削除されたキーが復活していないこと、有効なキーの値が正しいことを確認。
    - DB再起動後も整合性が保たれていることを確認。