### PR TITLE
docs: Update benchmark with parallel access analysis

### DIFF
--- a/docs/BENCHMARK_STAGE2.md
+++ b/docs/BENCHMARK_STAGE2.md
@@ -1,0 +1,59 @@
+# Stage 2 Benchmark Report
+
+## 実行環境
+- **OS**: macOS (darwin/arm64)
+- **CPU**: Apple M4 Pro
+- **Date**: 2026-01-03
+
+## 概要
+Stage 2 (削除機能・コンパクション実装) 完了時点でのベンチマーク結果です。
+削除ロジック (Tombstone判定) が追加されましたが、Coreの読み書き性能には大きな影響がないことを確認しました。
+
+## パフォーマンス・サマリー
+
+### 書き込み性能 (Put)
+| Payload Size | Latency (平均応答時間) | Throughput (推定処理能力) | Memory Allocations |
+|--------------|------------------------|---------------------------|--------------------|
+| **Small** (~8B) | **1.32 µs**            | **約 944,300 ops/sec**    | 218 B/op           |
+| **1 KB**       | **1.88 µs**            | **約 688,866 ops/sec**    | 1,273 B/op         |
+
+### 読み込み性能 (Get)
+| Payload Size | Latency (平均応答時間) | Throughput (推定処理能力) | Memory Allocations |
+|--------------|------------------------|---------------------------|--------------------|
+| **Small** (~8B) | **0.71 µs**            | **約 1,665,549 ops/sec**  | 21 B/op            |
+| **1 KB**       | **0.93 µs**            | **約 1,322,572 ops/sec**  | 2,193 B/op         |
+
+### 考察
+- **Impact Analysis**: Stage 1 と比較しても性能劣化は見られません。
+    - Put: 条件分岐 (Tombstoneサイズチェック) のコストは無視できるレベルです。
+    - Get: 変更なし (KeyDirからの直接Lookup) のため、高速性を維持しています。
+- **Note**: `Merge` (コンパクション) 処理自体のベンチマークはこのレポートには含まれていませんが、機能テスト (`TestMerge`) にて動作の正確性は検証済みです。
+
+---
+
+## 生データ (Raw Output)
+```text
+go test -v -bench=. -benchmem ./internal/...
+=== RUN   TestPutGet
+--- PASS: TestPutGet (0.00s)
+=== RUN   TestRecovery
+--- PASS: TestRecovery (0.00s)
+=== RUN   TestDelete
+--- PASS: TestDelete (0.00s)
+=== RUN   TestMerge
+--- PASS: TestMerge (0.00s)
+goos: darwin
+goarch: arm64
+pkg: bitcask-go/internal/storage
+cpu: Apple M4 Pro
+BenchmarkPut
+BenchmarkPut-14           944300              1319 ns/op             218 B/op          5 allocs/op
+BenchmarkPut1KB
+BenchmarkPut1KB-14        688866              1883 ns/op            1273 B/op          4 allocs/op
+BenchmarkGet
+BenchmarkGet-14          1665549               711.3 ns/op            21 B/op          2 allocs/op
+BenchmarkGet1KB
+BenchmarkGet1KB-14       1322572               928.1 ns/op          2193 B/op          3 allocs/op
+PASS
+ok      bitcask-go/internal/storage     8.082s
+```

--- a/docs/BENCHMARK_STAGE2.md
+++ b/docs/BENCHMARK_STAGE2.md
@@ -1,4 +1,4 @@
-# Stage 2 Benchmark Report
+# Stage 2 Benchmark Report (with Concurrency Analysis)
 
 ## 実行環境
 - **OS**: macOS (darwin/arm64)
@@ -6,54 +6,54 @@
 - **Date**: 2026-01-03
 
 ## 概要
-Stage 2 (削除機能・コンパクション実装) 完了時点でのベンチマーク結果です。
-削除ロジック (Tombstone判定) が追加されましたが、Coreの読み書き性能には大きな影響がないことを確認しました。
+Stage 2 時点での性能評価レポートです。
+通常のシーケンシャルアクセス性能に加え、並列アクセス (`RunParallel`) 時の挙動についても検証を行いました。
 
 ## パフォーマンス・サマリー
 
-### 書き込み性能 (Put)
+### 基本性能 (Sequential / Payload: Mixed)
 | Payload Size | Latency (平均応答時間) | Throughput (推定処理能力) | Memory Allocations |
 |--------------|------------------------|---------------------------|--------------------|
-| **Small** (~8B) | **1.32 µs**            | **約 944,300 ops/sec**    | 218 B/op           |
-| **1 KB**       | **1.88 µs**            | **約 688,866 ops/sec**    | 1,273 B/op         |
+| **Put (Small)**| **1.21 µs**            | **約 824,000 ops/sec**    | 183 B/op           |
+| **Put (1 KB)** | **1.81 µs**            | **約 552,000 ops/sec**    | 1,271 B/op         |
+| **Get (Small)**| **0.71 µs**            | **約 1,410,000 ops/sec**  | 21 B/op            |
+| **Get (1 KB)** | **0.89 µs**            | **約 1,120,000 ops/sec**  | 2,193 B/op         |
 
-### 読み込み性能 (Get)
-| Payload Size | Latency (平均応答時間) | Throughput (推定処理能力) | Memory Allocations |
-|--------------|------------------------|---------------------------|--------------------|
-| **Small** (~8B) | **0.71 µs**            | **約 1,665,549 ops/sec**  | 21 B/op            |
-| **1 KB**       | **0.93 µs**            | **約 1,322,572 ops/sec**  | 2,193 B/op         |
+### 並列アクセス性能 (Concurrency)
+`gomaxprocs` (CPUコア数) に応じた並列負荷をかけた場合の結果です。
 
-### 考察
-- **Impact Analysis**: Stage 1 と比較しても性能劣化は見られません。
-    - Put: 条件分岐 (Tombstoneサイズチェック) のコストは無視できるレベルです。
-    - Get: 変更なし (KeyDirからの直接Lookup) のため、高速性を維持しています。
-- **Note**: `Merge` (コンパクション) 処理自体のベンチマークはこのレポートには含まれていませんが、機能テスト (`TestMerge`) にて動作の正確性は検証済みです。
+| Operation | Sequential Latency | Parallel Latency | Throughput Check |
+|-----------|--------------------|-------------------|------------------|
+| **Put**   | 1.21 µs            | **1.63 µs**       | 📉 低下 (-25%)   |
+| **Get**   | 0.71 µs            | **2.16 µs**       | 📉 低下 (-67%)   |
+
+## 考察と分析
+
+### 1. 書き込み (Put) の並列性
+- **傾向**: 並列化により性能が低下しました。
+- **原因**: Bitcaskモデル（LSMツリーのWAL部分と同様）は、単一ファイルへの追記型アーキテクチャを持ちます。
+  `sync.Mutex` により書き込みが直列化されるため、並列数を増やしてもディスクI/Oのスループット向上は見込めず、むしろロック競合（Contention）とCPUコンテキストスイッチのオーバーヘッドが上乗せされる結果となりました。
+
+### 2. 読み込み (Get) の並列性
+- **傾向**: こちらもスループットが悪化する結果となりました。
+- **原因**:
+    - **ロック競合**: `sync.RWMutex.RLock` は共有ロックですが、高頻度な取得/解放はCPUキャッシュラインの競合を引き起こします。
+    - **システムコール**: 小さなデータの `read` syscall を大量の並列度で発行した場合、OS側のファイルシステムレイヤーでのオーバーヘッドが支配的になります。
+    - **ベンチマークの性質**: `fmt.Sprintf` 等の文字列操作によるメモリアロケーションが並列実行時に競合した可能性も含まれます。
+
+### 結論
+現状のアーキテクチャにおいて、**過度な並列化は逆効果**となる可能性があります。
+将来的には、バッチ書き込み（Batch Commit）機能の導入や、コネクションプーリングによる同時実行数制御がパフォーマンス向上に有効であると考えられます。
 
 ---
 
 ## 生データ (Raw Output)
 ```text
 go test -v -bench=. -benchmem ./internal/...
-=== RUN   TestPutGet
---- PASS: TestPutGet (0.00s)
-=== RUN   TestRecovery
---- PASS: TestRecovery (0.00s)
-=== RUN   TestDelete
---- PASS: TestDelete (0.00s)
-=== RUN   TestMerge
---- PASS: TestMerge (0.00s)
-goos: darwin
-goarch: arm64
-pkg: bitcask-go/internal/storage
-cpu: Apple M4 Pro
-BenchmarkPut
-BenchmarkPut-14           944300              1319 ns/op             218 B/op          5 allocs/op
-BenchmarkPut1KB
-BenchmarkPut1KB-14        688866              1883 ns/op            1273 B/op          4 allocs/op
-BenchmarkGet
-BenchmarkGet-14          1665549               711.3 ns/op            21 B/op          2 allocs/op
-BenchmarkGet1KB
-BenchmarkGet1KB-14       1322572               928.1 ns/op          2193 B/op          3 allocs/op
-PASS
-ok      bitcask-go/internal/storage     8.082s
+BenchmarkPut-14                   886838              1213 ns/op             183 B/op          5 allocs/op
+BenchmarkPut1KB-14                701398              1810 ns/op            1271 B/op          4 allocs/op
+BenchmarkGet-14                  1662559               707.1 ns/op            21 B/op          2 allocs/op
+BenchmarkGet1KB-14               1332290               889.4 ns/op          2193 B/op          3 allocs/op
+BenchmarkPutParallel-14           805942              1634 ns/op             106 B/op          5 allocs/op
+BenchmarkGetParallel-14           537409              2155 ns/op             288 B/op          3 allocs/op
 ```


### PR DESCRIPTION
## 概要
並列アクセス () 時のベンチマーク計測コードを追加し、レポート () に分析結果を追記しました。

## 分析結果サマリー
並列化によりスループットが低下することを確認。
- **Put**: ロック競合によるオーバーヘッドのため約25%低下。
- **Get**: ロック、システムコール、メモリアロケーションの競合により約67%低下。

現行アーキテクチャ（単一ファイルへの追記型モデル）の特性を裏付ける結果が得られました。