### PR TITLE
feat: Stage 2 - The Guardian (Checksums)

### DIFF
--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -220,7 +220,7 @@ func TestChecksum(t *testing.T) {
 	if _, err := file.WriteAt([]byte{0xFF}, off); err != nil {
 		t.Fatalf("Failed to corrupt file: %v", err)
 	}
-	file.Close()
+	_ = file.Close()
 
 	// 3. 起動時チェック (Guardian)
 	// loadKeyDirでCRC不整合を検知してエラーになるはず


### PR DESCRIPTION
## Overview
Implemented Stage 2 'The Guardian' features following the roadmap.
Introduced CRC32 checksums for data integrity.

## Changes
- **Data Format Update**:
  `[Timestamp][Sizes][Key][Value]` -> `[CRC(4)][Timestamp][Sizes][Key][Value]`
  Added 4-byte CRC32 at the beginning of each record.

- **Integrity Checks**:
  - `Get()`: Verifies CRC on read.
  - `loadKeyDir()`: Verifies all records during index reconstruction.
  - `Merge()`: Verifies data during compaction.

## Tests
- `TestChecksum`: Verified that corrupted data is detected (loadKeyDir returns error).