### PR TITLE
feat: Stage 3 - Segmentation (Part 1)

### DIFF
--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -76,7 +76,7 @@ func NewDB(dirPath string) (*DB, error) {
 	// 全ファイルをロードしてインデックス構築
 	for _, id := range fileIDs {
 		if err := db.loadFile(id); err != nil {
-			db.Close()
+			_ = db.Close()
 			return nil, err
 		}
 	}
@@ -85,7 +85,7 @@ func NewDB(dirPath string) (*DB, error) {
 	if len(fileIDs) == 0 {
 		// 新規作成
 		if err := db.newActiveFile(0); err != nil {
-			db.Close()
+			_ = db.Close()
 			return nil, err
 		}
 	} else {
@@ -103,7 +103,7 @@ func NewDB(dirPath string) (*DB, error) {
 		// オフセットは末尾へ (loadFileでSeekしてないかもしれないので念のため)
 		info, err := f.Stat()
 		if err != nil {
-			db.Close()
+			_ = db.Close()
 			return nil, err
 		}
 		db.writeOffset = info.Size()


### PR DESCRIPTION
## Overview
Implemented file segmentation (Log-Structured Architecture) as part of Stage 3 'The Cleaner'.
- Data is now stored in directory-based structure (e.g. `db_dir/0.data`, `db_dir/1.data`).
- Active file rotates when it exceeds 10MB limit.
- Modified `RecordPos` to include `FileID`.
- Updated all tests to support directory structure.

## Note
- `Merge` (Compaction) is temporarily disabled/unimplemented in this PR to keep diff size manageable. It will be re-implemented in Part 2.