### PR TITLE
feat: Stage 5 - The Zero-Copy (mmap)

### DIFF
--- a/docs/BENCHMARK_STAGE5.md
+++ b/docs/BENCHMARK_STAGE5.md
@@ -1,0 +1,33 @@
+# Stage 5 Benchmark Report (mmap)
+
+## 実行環境
+- **OS**: macOS (darwin/arm64)
+- **CPU**: Apple M4 Pro
+- **Date**: 2026-01-03
+
+## 概要
+Stage 5 "The Zero-Copy" では、不変ファイル（`olderFiles`）へのアクセス最適化を行いました。
+従来の `os.File.ReadAt`（システムコール + コピー）から、**`mmap` (Memory-Mapped Files)** を用いたダイレクトメモリアクセスに変更しました。
+
+## パフォーマンス計測
+ベンチマーク条件:
+- データセット: 2,000レコード (1KB Value), Total ~2MB
+- 測定対象: **古いセグメントファイル (`olderFiles`) からのランダムリード**
+- ファイルサイズを小さく抑え強制的にローテーションさせ、古いファイルへのアクセスを発生させた。
+
+| Metric | Latency / Throughput | Note |
+|--------|----------------------|------|
+| **Get Latency (Single)** | **461.6 ns/op** | 非常に高速 (Memory Access Speed) |
+| **Get Latency (Parallel)** | **620.7 ns/op** | Lock Contention Overhead |
+
+### 考察
+- **ゼロコピー効果**: 461ns という数値は、通常のディスクI/O (数µs〜) では到達不可能な速度です。データ全体がOSのページキャッシュに乗っている状態とはいえ、`read` システムコールのオーバーヘッドさえも回避し、単なる `memcpy` 相当の速度でデータ取得ができています。
+- **ロックのボトルネック**: 読み出しがあまりに高速化されたため、相対的に `sync.RWMutex` のロックコストが見え始めています（Parallelの方が遅い現象）。これは次の Stage 6 (Sharding) で解消すべき課題です。
+
+## 生データ (Raw Output)
+```text
+BenchmarkGetOlder
+BenchmarkGetOlder-14                     2634426               461.6 ns/op          3368 B/op          5 allocs/op
+BenchmarkGetOlderParallel
+BenchmarkGetOlderParallel-14             1866003               620.7 ns/op          3368 B/op          5 allocs/op
+```

--- a/internal/storage/reader.go
+++ b/internal/storage/reader.go
@@ -1,0 +1,101 @@
+package storage
+
+import (
+	"io"
+	"os"
+	"syscall"
+)
+
+// Reader is an abstraction for file access, allowing both standard I/O and mmap.
+type Reader interface {
+	io.ReaderAt
+	io.Closer
+	Size() int64
+}
+
+// DiskReader wraps a standard *os.File.
+type DiskReader struct {
+	f *os.File
+}
+
+func NewDiskReader(f *os.File) *DiskReader {
+	return &DiskReader{f: f}
+}
+
+func (d *DiskReader) ReadAt(b []byte, off int64) (int, error) {
+	return d.f.ReadAt(b, off)
+}
+
+func (d *DiskReader) Close() error {
+	return d.f.Close()
+}
+
+func (d *DiskReader) Size() int64 {
+	info, err := d.f.Stat()
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}
+
+// MmapReader uses memory-mapped files for zero-copy reads.
+type MmapReader struct {
+	f    *os.File
+	data []byte
+	size int64
+}
+
+func NewMmapReader(path string) (*MmapReader, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	size := info.Size()
+
+	if size == 0 {
+		// Empty file cannot be mmapped
+		return &MmapReader{f: f, data: nil, size: 0}, nil
+	}
+
+	// PROT_READ: Read only
+	// MAP_SHARED: Changes are shared (though we treat it as immutable)
+	data, err := syscall.Mmap(int(f.Fd()), 0, int(size), syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+
+	return &MmapReader{f: f, data: data, size: size}, nil
+}
+
+func (m *MmapReader) ReadAt(b []byte, off int64) (int, error) {
+	if off < 0 || off >= m.size {
+		return 0, io.EOF
+	}
+	if off+int64(len(b)) > m.size {
+		// Partial read at EOF
+		copy(b, m.data[off:])
+		return int(m.size - off), io.EOF // Return EOF for partial read to match io.ReaderAt contract? io.ReaderAt says "n < len(b) => err"
+	}
+	copy(b, m.data[off:off+int64(len(b))])
+	return len(b), nil
+}
+
+func (m *MmapReader) Close() error {
+	if m.data != nil {
+		if err := syscall.Munmap(m.data); err != nil {
+			return err
+		}
+	}
+	return m.f.Close()
+}
+
+func (m *MmapReader) Size() int64 {
+	return m.size
+}


### PR DESCRIPTION
## Overview
Implemented Memory-Mapped Files (mmap) support for immutable data files to maximize read performance.

## Changes
- **FileReader Interface**: Abstracted file access to support both `os.File` and `mmap`.
- **MmapReader**: Implemented zero-copy reader using `syscall.Mmap`.
- **DB Integration**: Updated `olderFiles` (immutable segments) to use `MmapReader`.

## Performance (Benchmark)
Random Read Latency from Older Files:
- **Latency**: **461.6 ns/op** (Extremely fast, near memory speed)
- **Zero-Copy**: Reduced system call overhead for read operations on compacted files.

## Note
Active file still uses standard I/O for append operations. Only immutable segments are mmapped.